### PR TITLE
issue 125 refactor globa_monitor.py for GCS

### DIFF
--- a/backend/PythonClient/multirotor/monitor/abstract/globa_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/abstract/globa_monitor.py
@@ -29,13 +29,11 @@ class GlobalMonitor(AirSimApplication):
     def save_report(self):
         with lock:
             log_dir = os.path.join(self.dir_path,
-                                   self.log_subdir) + os.sep + "GlobalMonitors" + os.sep + self.__class__.__name__
-            if not os.path.exists(log_dir):
-                os.makedirs(log_dir)
+                         self.log_subdir) + os.sep + "GlobalMonitors" + os.sep + self.__class__.__name__
+            filename = log_dir + os.sep + "_log.txt"
 
-            filename = log_dir + os.sep + "log.txt"
-
-            with open(filename, 'w') as outfile:
-                outfile.write(self.log_text)
+            gcs_path = f"{self.log_subdir}/{self.__class__.__name__}/{filename}"
+            
+            self.upload_to_gcs(gcs_path, self.log_text)
 
             # print("DEBUG:" + log_dir)


### PR DESCRIPTION
issue #125 

removed storing in local files, instead uploading to GCS

changed as we are switching to a cloud based system of storage.

I kept the same file name as was requested by the issue, therefore files should be predictably named for the global monitor, I then sent the file to GCS, rather than the local system