### PR TITLE
update docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 name: DroneWorld
 services:
   backend:
+    image: mohamdlog/droneworld-backend:v1.0.0
     build: ./backend
     ports:
       - "5000:5000"
@@ -9,6 +10,7 @@ services:
       - ./config/airsim:/root/Documents/AirSim  # Mount the AirSim folder
 
   frontend:
+    image: mohamdlog/droneworld-frontend:v1.0.0
     build: ./frontend
     ports:
       - "3000:3000"


### PR DESCRIPTION
In this PR, I updated the `docker-compose.yml` configuration to give users the flexibility to either pull pre-built Docker images automatically or manually build the images from the source code. This change allows for quicker setup using pre-built images while still supporting custom builds when needed.