### PR TITLE
Replaces every instance of upload_to_gcs with save_report_to_storage

### DIFF
--- a/backend/PythonClient/multirotor/mission/abstract/abstract_mission.py
+++ b/backend/PythonClient/multirotor/mission/abstract/abstract_mission.py
@@ -37,7 +37,7 @@ class GenericMission(AirSimApplication):
             gcs_path = f"{self.log_subdir}/{self.__class__.__name__}/{file_name}"
 
             # Upload directly to GCS (log_text is uploaded as file content)
-            self.upload_to_gcs(gcs_path, self.log_text)
+            self.save_report_to_storage(gcs_path, self.log_text)
 
     def kill_mission(self):
         self.state = self.State.END

--- a/backend/PythonClient/multirotor/monitor/abstract/globa_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/abstract/globa_monitor.py
@@ -33,6 +33,6 @@ class GlobalMonitor(AirSimApplication):
             gcs_path = f"{self.log_subdir}/GlobalMonitors/{self.__class__.__name__}/{file_name}"
 
             # Upload directly to GCS (log_text is uploaded as file content)
-            self.upload_to_gcs(gcs_path, self.log_text)
+            self.save_report_to_storage(gcs_path, self.log_text)
 
             # print("DEBUG:" + log_dir)

--- a/backend/PythonClient/multirotor/monitor/abstract/single_drone_mission_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/abstract/single_drone_mission_monitor.py
@@ -42,4 +42,4 @@ class SingleDroneMissionMonitor(AirSimApplication):
             gcs_path = f"{self.log_subdir}/{self.mission.__class__.__name__}/{self.__class__.__name__}/{file_name}"
 
             # Upload directly to GCS (log_text is uploaded as file content)
-            self.upload_to_gcs(gcs_path, self.log_text)
+            self.save_report_to_storage(gcs_path, self.log_text)

--- a/backend/PythonClient/multirotor/monitor/point_deviation_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/point_deviation_monitor.py
@@ -149,7 +149,7 @@ class PointDeviationMonitor(SingleDroneMissionMonitor):
         gcs_path = f"{self.log_subdir}/FlyToPoints/{self.__class__.__name__}/{self.target_drone}_interactive.html"
         with lock:
             try:        
-                self.upload_to_gcs(gcs_path, interactive_html_content, content_type='text/html')
+                self.save_report_to_storage(gcs_path, interactive_html_content, content_type='text/html')
             except Exception as e:
                 print(f"Failed to upload html to GCS. Error: {str(e)}")
 


### PR DESCRIPTION
Fixes #147 

The code allows for all files of their specific types to be uploaded to the GCS using a new method, save_report_to_storage. This new method replaces all instances of the upload_to_gcs method. 

This was needed to allow for code reusability through the use of an interface and better streamlining and naming of all our functions. This helps prevent code mistakes from misreading or misplacement.  

Four instances of upload_to_gcs were changed to save_report_to_storage. Functionality stayed the same. 