### PR TITLE
Fix pass/fail extra counts

### DIFF
--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -80,7 +80,7 @@ def list_reports():
                     continue  # Skip if not in a monitor subdirectory
                 monitor = sub_parts[2]
                 if 'fuzzy' in monitor.lower():
-                    contains_fuzzy = Truegit 
+                    contains_fuzzy = True
                 
                 # Count 'PASS' and 'FAIL' directly in the blob content
                 if sub_blob.name.endswith('.txt'):

--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -80,7 +80,7 @@ def list_reports():
                     continue  # Skip if not in a monitor subdirectory
                 monitor = sub_parts[2]
                 if 'fuzzy' in monitor.lower():
-                    contains_fuzzy = True
+                    contains_fuzzy = Truegit 
                 
                 # Count 'PASS' and 'FAIL' directly in the blob content
                 if sub_blob.name.endswith('.txt'):

--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -86,8 +86,10 @@ def list_reports():
                 if sub_blob.name.endswith('.txt'):
                     # Download and read the text file contents
                     file_contents = sub_blob.download_as_text()
-                    pass_count += file_contents.count("PASS")
-                    fail_count += file_contents.count("FAIL")
+                    if "FAIL" in file_contents:
+                        fail_count += 1
+                    elif "PASS" in file_contents:
+                        pass_count += 1
 
             report['contains_fuzzy'] = contains_fuzzy
             report['drone_count'] = drone_count


### PR DESCRIPTION
Counting each `PASS` or `FAIL` in a file can give unexpected results since a file may contain multiple entries. Instead, we’ll just check if there’s a `PASS` or `FAIL` in each log file, so each file only counts as one pass or fail.