### PR TITLE
166 add functionality to upload log text report files to google drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,4 @@ frontend/package-lock.json
 # Ignore Windows system file
 desktop.ini
 
-# Ignore Google Cloud service account key
 key.json
-backend/key.json

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ desktop.ini
 
 # Ignore Google Cloud service account key
 key.json
+backend/key.json

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ frontend/package-lock.json
 # Ignore Windows system file
 desktop.ini
 
+# Ignore Google Cloud service account key
 key.json

--- a/backend/PythonClient/multirotor/airsim_application.py
+++ b/backend/PythonClient/multirotor/airsim_application.py
@@ -6,12 +6,12 @@ from abc import abstractmethod
 
 from PythonClient import airsim
 from PythonClient.multirotor.storage import GCSStorageService, GoogleDriveStorageService
+
 class AirSimApplication:
     # Parent class for all airsim client side mission and monitors
     def __init__(self):
-        # implementation of the GCS service
-        #self.storage_service = GCSStorageService()
-        self.storage_service = GoogleDriveStorageService()
+        # Set up the storage service
+        self.storage_service = GCSStorageService()
 
         self.circular_mission_names = {"FlyInCircle"}
         self.polygon_mission_names = {"FlyToPoints", "FlyToPointsGeo"}

--- a/backend/PythonClient/multirotor/airsim_application.py
+++ b/backend/PythonClient/multirotor/airsim_application.py
@@ -6,12 +6,12 @@ from abc import abstractmethod
 
 from PythonClient import airsim
 from PythonClient.multirotor.storage import GCSStorageService, GoogleDriveStorageService
-
 class AirSimApplication:
     # Parent class for all airsim client side mission and monitors
     def __init__(self):
         # implementation of the GCS service
-        self.storage_service = GCSStorageService()
+        #self.storage_service = GCSStorageService()
+        self.storage_service = GoogleDriveStorageService()
 
         self.circular_mission_names = {"FlyInCircle"}
         self.polygon_mission_names = {"FlyToPoints", "FlyToPointsGeo"}

--- a/backend/PythonClient/multirotor/storage/gd_storage_service.py
+++ b/backend/PythonClient/multirotor/storage/gd_storage_service.py
@@ -1,4 +1,4 @@
-from abstract.storage_service import StorageServiceInterface
+from PythonClient.multirotor.storage.abstract.storage_service import StorageServiceInterface
 # backend.PythonClient.multirotor.storage.abstract.
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -19,7 +19,7 @@ class GoogleDriveStorageService(StorageServiceInterface):
         """
         SCOPES = ['https://www.googleapis.com/auth/drive']
         self.credentials = service_account.Credentials.from_service_account_file(
-            'backend/key.json', scopes=SCOPES)
+            'key.json', scopes=SCOPES)
         self.service = build('drive', 'v3', credentials=self.credentials)
         self.folder_id = folder_id  # The ID of the shared root folder
 

--- a/backend/PythonClient/multirotor/storage/gd_storage_service.py
+++ b/backend/PythonClient/multirotor/storage/gd_storage_service.py
@@ -24,6 +24,20 @@ class GoogleDriveStorageService(StorageServiceInterface):
 
     def upload_to_service(self, file_name, content, content_type='text/plain'):
         """
-        Uploads a file to the cloud storage service.
+        Uploads a file to the Google Drive.
         """
-        pass
+        
+        with self._lock:  # Prevent race conditions
+            try:
+                # Prepare file metadata and content
+                media = MediaInMemoryUpload(content.encode('utf-8'), mimetype=content_type)
+                metadata = {'name': file_name, 'parents': [self.folder_id]}
+
+                # Upload the file
+                file_id = self.service.files().create(body=metadata, media_body=media, fields='id').execute().get('id')
+                print(f"Uploaded '{file_name}' with ID: {file_id}")
+                return file_id
+
+            except Exception as e:
+                print(f"Upload error: {e}")
+                return None

--- a/backend/PythonClient/multirotor/storage/gd_storage_service.py
+++ b/backend/PythonClient/multirotor/storage/gd_storage_service.py
@@ -1,4 +1,5 @@
-from PythonClient.multirotor.storage.abstract.storage_service import StorageServiceInterface
+from abstract.storage_service import StorageServiceInterface
+# backend.PythonClient.multirotor.storage.abstract.
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaInMemoryUpload
@@ -18,7 +19,7 @@ class GoogleDriveStorageService(StorageServiceInterface):
         """
         SCOPES = ['https://www.googleapis.com/auth/drive']
         self.credentials = service_account.Credentials.from_service_account_file(
-            'key.json', scopes=SCOPES)
+            'backend/key.json', scopes=SCOPES)
         self.service = build('drive', 'v3', credentials=self.credentials)
         self.folder_id = folder_id  # The ID of the shared root folder
 
@@ -26,7 +27,7 @@ class GoogleDriveStorageService(StorageServiceInterface):
         """
         Uploads a file to the Google Drive.
         """
-        
+
         with self._lock:  # Prevent race conditions
             try:
                 # Prepare file metadata and content
@@ -41,3 +42,24 @@ class GoogleDriveStorageService(StorageServiceInterface):
             except Exception as e:
                 print(f"Upload error: {e}")
                 return None
+
+
+def main():
+    # Initialize Google Drive storage service with default folder ID and credentials
+    drive_service = GoogleDriveStorageService()
+
+    # Sample file details
+    file_name = 'test_log.txt'
+    content = 'This is a test log file content with relative path.'
+
+    # Upload the file
+    file_id = drive_service.upload_to_service(file_name, content)
+
+    # Verify upload
+    if file_id:
+        print(f"File uploaded successfully with ID: {file_id}")
+    else:
+        print("File upload failed.")
+
+if __name__ == "__main__":
+    main()

--- a/backend/PythonClient/multirotor/storage/gd_storage_service.py
+++ b/backend/PythonClient/multirotor/storage/gd_storage_service.py
@@ -21,3 +21,9 @@ class GoogleDriveStorageService(StorageServiceInterface):
             'key.json', scopes=SCOPES)
         self.service = build('drive', 'v3', credentials=self.credentials)
         self.folder_id = folder_id  # The ID of the shared root folder
+
+    def upload_to_service(self, file_name, content, content_type='text/plain'):
+        """
+        Uploads a file to the cloud storage service.
+        """
+        pass


### PR DESCRIPTION
#166 
allows for automatic uploading of log files to Google Drive

this was added incase Google Cloud is unwanted/unavailable/ to allow for easier use of other storage devices

Built out from the previously created abstract storage service class, locks the thread during upload, creates the text file, the meta data for the upload, and uploads using the key.json.
Further, there is built-in testing if the gd_storage_service.py is ran as main.