### PR TITLE
Issue 167 HTML file Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "terminal.integrated.shellIntegration.enabled": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "terminal.integrated.shellIntegration.enabled": false
-}

--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -154,80 +154,51 @@ def process_gcs_directory(prefix, result, fuzzy_path_value):
     Processes blobs in a GCS directory and populates the result dictionary.
     """
     blobs = bucket.list_blobs(prefix=prefix)
+
+    def extract_fuzzy_value(fuzzy_path):
+        return fuzzy_path.split("_")[-1] if fuzzy_path else ""
+    
+    def classify_and_append(blob_name, file_data):
+        for monitor_type in result.keys():
+            if monitor_type in blob_name:
+                result[monitor_type].append(file_data)
+                break
+    
     for blob in blobs:
         file_name = os.path.basename(blob.name)
+        fuzzy_value = extract_fuzzy_value(fuzzy_path_value)
         
         if blob.name.endswith('.html'):
             # Generate a public URL for the HTML file
             html_url = blob.public_url
 
-            info_content = get_info_contents(html_url, "INFO", {})
-            pass_content = get_info_contents(html_url, "PASS", {})
-            fail_content = get_info_contents(html_url, "FAIL", {})
-
             file_data = {
                 "name": file_name,
                 "type": "text/html",
                 "fuzzyPath": fuzzy_path_value,
-                "fuzzyValue": fuzzy_path_value.split("_")[-1] if fuzzy_path_value else "",
+                "fuzzyValue": fuzzy_value,
                 "content": html_url,
-                "infoContent": info_content,
-                "passContent": pass_content,
-                "failContent": fail_content
+                "infoContent": get_info_contents(html_url, "INFO", {}),
+                "passContent": get_info_contents(html_url, "PASS", {}),
+                "failContent": get_info_contents(html_url, "FAIL", {})
             }
+            classify_and_append(blob.name, file_data)
 
             # Determine the monitor type and append the file data
-            if "UnorderedWaypointMonitor" in blob.name:
-                result["UnorderedWaypointMonitor"].append(file_data)
-            elif "CircularDeviationMonitor" in blob.name:
-                result["CircularDeviationMonitor"].append(file_data)
-            elif "CollisionMonitor" in blob.name:
-                result["CollisionMonitor"].append(file_data)
-            elif "LandspaceMonitor" in blob.name:
-                result["LandspaceMonitor"].append(file_data)
-            elif "OrderedWaypointMonitor" in blob.name:
-                result["OrderedWaypointMonitor"].append(file_data)
-            elif "PointDeviationMonitor" in blob.name:
-                result["PointDeviationMonitor"].append(file_data)
-            elif "MinSepDistMonitor" in blob.name:
-                result["MinSepDistMonitor"].append(file_data)
-            elif "NoFlyZoneMonitor" in blob.name:
-                result["NoFlyZoneMonitor"].append(file_data)
-
         elif blob.name.endswith('.txt'):
             file_contents = blob.download_as_text()
-            
-            info_content = get_info_contents(file_contents, "INFO", {})
-            pass_content = get_info_contents(file_contents, "PASS", {})
-            fail_content = get_info_contents(file_contents, "FAIL", {})
-
+    
             file_data = {
                 "name": file_name, 
                 "type": "text/plain",
                 "fuzzyPath": fuzzy_path_value,
-                "fuzzyValue": fuzzy_path_value.split("_")[-1] if fuzzy_path_value else "",
+                "fuzzyValue": fuzzy_value,
                 "content": file_contents,
-                "infoContent": info_content,
-                "passContent": pass_content,
-                "failContent": fail_content
+                "infoContent": get_info_contents(html_url, "INFO", {}),
+                "passContent": get_info_contents(html_url, "PASS", {}),
+                "failContent": get_info_contents(html_url, "FAIL", {})
             }
-
-            if "UnorderedWaypointMonitor" in blob.name:
-                result["UnorderedWaypointMonitor"].append(file_data)
-            elif "CircularDeviationMonitor" in blob.name:
-                result["CircularDeviationMonitor"].append(file_data)
-            elif "CollisionMonitor" in blob.name:
-                result["CollisionMonitor"].append(file_data)
-            elif "LandspaceMonitor" in blob.name:
-                result["LandspaceMonitor"].append(file_data)
-            elif "OrderedWaypointMonitor" in blob.name:
-                result["OrderedWaypointMonitor"].append(file_data)
-            elif "PointDeviationMonitor" in blob.name:
-                result["PointDeviationMonitor"].append(file_data)
-            elif "MinSepDistMonitor" in blob.name:
-                result["MinSepDistMonitor"].append(file_data)
-            elif "NoFlyZoneMonitor" in blob.name:
-                result["NoFlyZoneMonitor"].append(file_data)
+            classify_and_append(blob.name, file_data)
 
         elif blob.name.endswith('.png'):
             # Download and encode the image in base64
@@ -241,28 +212,11 @@ def process_gcs_directory(prefix, result, fuzzy_path_value):
                 "name": file_name,
                 "type": "image/png",
                 "fuzzyPath": fuzzy_path_value,
-                "fuzzyValue": fuzzy_path_value.split("_")[-1] if fuzzy_path_value else "",
+                "fuzzyValue": fuzzy_value,
                 "imgContent": encoded_string,
                 "path": html_path
             }
-
-            # Determine the monitor type and append the file data
-            if "UnorderedWaypointMonitor" in blob.name:
-                result["UnorderedWaypointMonitor"].append(file_data)
-            elif "CircularDeviationMonitor" in blob.name:
-                result["CircularDeviationMonitor"].append(file_data)
-            elif "CollisionMonitor" in blob.name:
-                result["CollisionMonitor"].append(file_data)
-            elif "LandspaceMonitor" in blob.name:
-                result["LandspaceMonitor"].append(file_data)
-            elif "OrderedWaypointMonitor" in blob.name:
-                result["OrderedWaypointMonitor"].append(file_data)
-            elif "PointDeviationMonitor" in blob.name:
-                result["PointDeviationMonitor"].append(file_data)
-            elif "MinSepDistMonitor" in blob.name:
-                result["MinSepDistMonitor"].append(file_data)
-            elif "NoFlyZoneMonitor" in blob.name:
-                result["NoFlyZoneMonitor"].append(file_data)
+            classify_and_append(blob.name, file_data)            
 
 def get_info_contents(file_contents, keyword, drone_map):
     """

--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -205,16 +205,12 @@ def process_gcs_directory(prefix, result, fuzzy_path_value):
             image_content = blob.download_as_bytes()
             encoded_string = base64.b64encode(image_content).decode('utf-8')
 
-            # Assume corresponding HTML exists
-            html_path = blob.name.replace("_plot.png", "_interactive.html")
-
             file_data = {
                 "name": file_name,
                 "type": "image/png",
                 "fuzzyPath": fuzzy_path_value,
                 "fuzzyValue": fuzzy_value,
                 "imgContent": encoded_string,
-                "path": html_path
             }
             classify_and_append(blob.name, file_data)     
 

--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -216,7 +216,7 @@ def process_gcs_directory(prefix, result, fuzzy_path_value):
                 "imgContent": encoded_string,
                 "path": html_path
             }
-            classify_and_append(blob.name, file_data)            
+            classify_and_append(blob.name, file_data)     
 
 def get_info_contents(file_contents, keyword, drone_map):
     """

--- a/backend/PythonClient/server/simulation_server.py
+++ b/backend/PythonClient/server/simulation_server.py
@@ -156,16 +156,53 @@ def process_gcs_directory(prefix, result, fuzzy_path_value):
     blobs = bucket.list_blobs(prefix=prefix)
     for blob in blobs:
         file_name = os.path.basename(blob.name)
-        if blob.name.endswith('.txt'):
-            # Download the text content
-            file_contents = blob.download_as_text()
+        
+        if blob.name.endswith('.html'):
+            # Generate a public URL for the HTML file
+            html_url = blob.public_url
 
+            info_content = get_info_contents(html_url, "INFO", {})
+            pass_content = get_info_contents(html_url, "PASS", {})
+            fail_content = get_info_contents(html_url, "FAIL", {})
+
+            file_data = {
+                "name": file_name,
+                "type": "text/html",
+                "fuzzyPath": fuzzy_path_value,
+                "fuzzyValue": fuzzy_path_value.split("_")[-1] if fuzzy_path_value else "",
+                "content": html_url,
+                "infoContent": info_content,
+                "passContent": pass_content,
+                "failContent": fail_content
+            }
+
+            # Determine the monitor type and append the file data
+            if "UnorderedWaypointMonitor" in blob.name:
+                result["UnorderedWaypointMonitor"].append(file_data)
+            elif "CircularDeviationMonitor" in blob.name:
+                result["CircularDeviationMonitor"].append(file_data)
+            elif "CollisionMonitor" in blob.name:
+                result["CollisionMonitor"].append(file_data)
+            elif "LandspaceMonitor" in blob.name:
+                result["LandspaceMonitor"].append(file_data)
+            elif "OrderedWaypointMonitor" in blob.name:
+                result["OrderedWaypointMonitor"].append(file_data)
+            elif "PointDeviationMonitor" in blob.name:
+                result["PointDeviationMonitor"].append(file_data)
+            elif "MinSepDistMonitor" in blob.name:
+                result["MinSepDistMonitor"].append(file_data)
+            elif "NoFlyZoneMonitor" in blob.name:
+                result["NoFlyZoneMonitor"].append(file_data)
+
+        elif blob.name.endswith('.txt'):
+            file_contents = blob.download_as_text()
+            
             info_content = get_info_contents(file_contents, "INFO", {})
             pass_content = get_info_contents(file_contents, "PASS", {})
             fail_content = get_info_contents(file_contents, "FAIL", {})
 
             file_data = {
-                "name": file_name,
+                "name": file_name, 
                 "type": "text/plain",
                 "fuzzyPath": fuzzy_path_value,
                 "fuzzyValue": fuzzy_path_value.split("_")[-1] if fuzzy_path_value else "",
@@ -175,7 +212,6 @@ def process_gcs_directory(prefix, result, fuzzy_path_value):
                 "failContent": fail_content
             }
 
-            # Determine the monitor type and append the file data
             if "UnorderedWaypointMonitor" in blob.name:
                 result["UnorderedWaypointMonitor"].append(file_data)
             elif "CircularDeviationMonitor" in blob.name:


### PR DESCRIPTION
Fixes #167 

Modified the process_gcs_directory function to detect HTML files by generating a public URL for each HTML file. In addition, I ensured that the JSON includes a path attribute for HTML files containing the public URL.

 The GCS bucket in the process_gcs_directory did not include HTML files because it didn't recognize them. Including HTML files that are categorized properly helps reduce integration issues later and allows for easier testing and validation.

Checked the JSON response for HTML file details with a valid path and now HTML reports can be found under the acceptance reports.