### PR TITLE
Issue165

### DIFF
--- a/backend/PythonClient/multirotor/monitor/circular_deviation_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/circular_deviation_monitor.py
@@ -141,12 +141,14 @@ class CircularDeviationMonitor(SingleDroneMissionMonitor):
         for i in range(len(x)):
             planned.append([x[i], y[i], -z[i]])
 
-        ThreeDimensionalGrapher.draw_trace_vs_planned(planed_position_list=planned,
+        grapher = ThreeDimensionalGrapher(self.storage_service,self.log_subdir)
+
+        grapher.draw_trace_vs_planned(planed_position_list=planned,
                                                       actual_position_list=est_actual,
                                                       full_target_directory=graph_dir,
                                                       drone_name=self.target_drone,
                                                       title=title)
-        ThreeDimensionalGrapher.draw_interactive_trace_vs_planned(planed_position_list=planned,
+        grapher.draw_interactive_trace_vs_planned(planed_position_list=planned,
                                                                   actual_position_list=est_actual,
                                                                   full_target_directory=graph_dir,
                                                                   drone_name=self.target_drone,

--- a/backend/PythonClient/multirotor/monitor/circular_deviation_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/circular_deviation_monitor.py
@@ -94,7 +94,7 @@ class CircularDeviationMonitor(SingleDroneMissionMonitor):
                 if not self.reported_breach:
                     self.reported_breach = True
                     self.append_fail_to_log(f"{self.target_drone};First breach: deviated more than "
-                                            f"{self.deviation_percentage}meter from the planned route")
+                                            f"{self.deviation_percentage} meter from the planned route")
                 self.breach_flag = True
             self.est_position_array.append([x, y, z])
             self.obj_position_array.append([ox, oy, oz])
@@ -103,12 +103,12 @@ class CircularDeviationMonitor(SingleDroneMissionMonitor):
         # print(self.position_array)
 
     def check_breach(self, x, y, z):
-        #print(f"Checking breach, Current position: {round(x, 2)}, {round(y, 2)}, {round(z, 2)}, "
+        # print(f"Checking breach, Current position: {round(x, 2)}, {round(y, 2)}, {round(z, 2)}, "
         #      f"center: {self.mission.center.x_val}, {self.mission.center.y_val}, {self.mission.altitude}")
         return GeoUtil.is_point_close_to_circle([self.mission.center.x_val, self.mission.center.y_val, self.mission.altitude],
-                                         self.mission.radius,
-                                         [x, y, -z],
-                                         self.deviation_percentage)
+                                                self.mission.radius,
+                                                [x, y, -z],
+                                                self.deviation_percentage)
 
     def calculate_actual_distance(self):
         distance = 0.0
@@ -118,38 +118,40 @@ class CircularDeviationMonitor(SingleDroneMissionMonitor):
 
     @staticmethod
     def get_distance_btw_points(point_arr_1, point_arr_2):
-        return math.sqrt((point_arr_2[0] - point_arr_1[0]) ** 2 + (point_arr_2[1] - point_arr_1[1]) ** 2 + (
-                point_arr_2[2] - point_arr_1[2]) ** 2)
+        return math.sqrt((point_arr_2[0] - point_arr_1[0]) ** 2 +
+                         (point_arr_2[1] - point_arr_1[1]) ** 2 +
+                         (point_arr_2[2] - point_arr_1[2]) ** 2)
 
     def draw_trace_3d(self):
-        graph_dir = self.get_graph_dir()
+        # Construct folder path
+        folder_path = f"{self.log_subdir}/{self.mission.__class__.__name__}/{self.__class__.__name__}/"
         est_actual = self.est_position_array
         # obj_actual = self.obj_position_array
         radius = self.mission.radius
         height = self.mission.altitude
+
         if not self.breach_flag:
             title = f"{self.target_drone} Planned vs. Actual\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}"
         else:
             title = f"(FAILED) {self.target_drone} Planned vs. Actual\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}"
+
         center = [self.mission.center.x_val, self.mission.center.y_val, height]
         theta = np.linspace(0, 2 * np.pi, 100)
         x = center[0] + radius * np.cos(theta)
         y = center[1] + radius * np.sin(theta)
         z = np.ones(100) * height
 
-        planned = []
-        for i in range(len(x)):
-            planned.append([x[i], y[i], -z[i]])
+        planned = [[x[i], y[i], -z[i]] for i in range(len(x))]
 
-        grapher = ThreeDimensionalGrapher(self.storage_service,self.log_subdir)
-
+        # Use the grapher to draw and upload graphs
+        grapher = ThreeDimensionalGrapher(self.storage_service)
         grapher.draw_trace_vs_planned(planed_position_list=planned,
-                                                      actual_position_list=est_actual,
-                                                      full_target_directory=graph_dir,
-                                                      drone_name=self.target_drone,
-                                                      title=title)
+                                      actual_position_list=est_actual,
+                                      drone_name=self.target_drone,
+                                      title=title,
+                                      folder_path=folder_path)
         grapher.draw_interactive_trace_vs_planned(planed_position_list=planned,
-                                                                  actual_position_list=est_actual,
-                                                                  full_target_directory=graph_dir,
-                                                                  drone_name=self.target_drone,
-                                                                  title=title)
+                                                  actual_position_list=est_actual,
+                                                  drone_name=self.target_drone,
+                                                  title=title,
+                                                  folder_path=folder_path)

--- a/backend/PythonClient/multirotor/monitor/drift_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/drift_monitor.py
@@ -63,7 +63,7 @@ class DriftMonitor(SingleDroneMissionMonitor):
             title = f"(FAILED) Drift path\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}\n" \
                     f"Closest distance: {round(self.closest,2)} meters"
         graph_dir = self.get_graph_dir()
-        grapher = ThreeDimensionalGrapher()
+        grapher = ThreeDimensionalGrapher(self.storage_service,self.log_subdir)
         grapher.draw_trace_vs_point(destination_point=dest,
                                     actual_position_list=actual,
                                     full_target_directory=graph_dir,

--- a/backend/PythonClient/multirotor/monitor/drift_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/drift_monitor.py
@@ -29,7 +29,7 @@ class DriftMonitor(SingleDroneMissionMonitor):
 
     def make_drifted_array(self):
         dt = self.dt
-        closest = 9223372036854775807  # Max int
+        closest = float('inf')  # Maximum distance
         self.reached = False
         self.est_position_array = []
         while self.mission.state != self.mission.State.END:
@@ -54,26 +54,32 @@ class DriftMonitor(SingleDroneMissionMonitor):
                                     f"{round(self.threshold, 2)} meters. Closest distance: {round(closest, 2)} meters")
 
     def draw_trace_3d(self):
+        # Construct folder path for storage service
+        folder_path = f"{self.log_subdir}/{self.mission.__class__.__name__}/{self.__class__.__name__}/"
+
         actual = self.est_position_array
         dest = self.mission.point
+
+        # Determine the title based on whether the target was reached
         if self.reached:
             title = f"Drift path\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}\n" \
-                    f"Closest distance: {round(self.closest,2)} meters"
+                    f"Closest distance: {round(self.closest, 2)} meters"
         else:
             title = f"(FAILED) Drift path\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}\n" \
-                    f"Closest distance: {round(self.closest,2)} meters"
-        graph_dir = self.get_graph_dir()
-        grapher = ThreeDimensionalGrapher(self.storage_service,self.log_subdir)
+                    f"Closest distance: {round(self.closest, 2)} meters"
+
+        # Use the grapher to draw and upload graphs
+        grapher = ThreeDimensionalGrapher(self.storage_service)
         grapher.draw_trace_vs_point(destination_point=dest,
                                     actual_position_list=actual,
-                                    full_target_directory=graph_dir,
                                     drone_name=self.target_drone,
-                                    title=title)
+                                    title=title,
+                                    folder_path=folder_path)
         grapher.draw_interactive_trace_vs_point(actual_position=actual,
                                                 destination=dest,
-                                                full_target_directory=graph_dir,
                                                 drone_name=self.target_drone,
-                                                title=title)
+                                                title=title,
+                                                folder_path=folder_path)
 
 
 if __name__ == "__main__":

--- a/backend/PythonClient/multirotor/monitor/point_deviation_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/point_deviation_monitor.py
@@ -5,6 +5,7 @@ from PythonClient.multirotor.util.geo.geo_util import GeoUtil
 from PythonClient.multirotor.util.graph.three_dimensional_grapher import ThreeDimensionalGrapher
 from PythonClient.multirotor.monitor.abstract.single_drone_mission_monitor import SingleDroneMissionMonitor
 
+
 class PointDeviationMonitor(SingleDroneMissionMonitor):
 
     def __init__(self, mission, deviation_percentage=15):
@@ -123,22 +124,29 @@ class PointDeviationMonitor(SingleDroneMissionMonitor):
         return distance
 
     def draw_trace_3d(self):
-        graph_dir = self.get_graph_dir()
+        # Construct the folder path
+        folder_path = f"{self.log_subdir}/{self.mission.__class__.__name__}/{self.__class__.__name__}/"
+
+        # Ensure the title reflects the mission status
         if not self.breach_flag:
             title = f"{self.target_drone} Planned vs. Actual\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}"
         else:
             title = f"(FAILED) {self.target_drone} Planned vs. Actual\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}"
-        grapher = ThreeDimensionalGrapher(self.storage_service, self.log_subdir)
-        grapher.draw_trace_vs_planned(planed_position_list=self.mission.points,
-                                      actual_position_list=self.est_position_array,
-                                      full_target_directory=graph_dir,
-                                      drone_name=self.target_drone,
-                                      title=title
-                                      )
+    
+        # Draw and upload the graphs
+        grapher = ThreeDimensionalGrapher(self.storage_service)
+        grapher.draw_trace_vs_planned(
+            planed_position_list=self.mission.points,
+            actual_position_list=self.est_position_array,
+            drone_name=self.target_drone,
+            title=title,
+            folder_path=folder_path
+        )
 
-        grapher.draw_interactive_trace_vs_planned(planed_position_list=self.mission.points,
-                                                  actual_position_list=self.est_position_array,
-                                                  full_target_directory=graph_dir,
-                                                  drone_name=self.target_drone,
-                                                  title=title
-                                                  )
+        grapher.draw_interactive_trace_vs_planned(
+            planed_position_list=self.mission.points,
+            actual_position_list=self.est_position_array,
+            drone_name=self.target_drone,
+            title=title,
+            folder_path=folder_path
+        )

--- a/backend/PythonClient/multirotor/monitor/point_deviation_monitor.py
+++ b/backend/PythonClient/multirotor/monitor/point_deviation_monitor.py
@@ -5,7 +5,6 @@ from PythonClient.multirotor.util.geo.geo_util import GeoUtil
 from PythonClient.multirotor.util.graph.three_dimensional_grapher import ThreeDimensionalGrapher
 from PythonClient.multirotor.monitor.abstract.single_drone_mission_monitor import SingleDroneMissionMonitor
 
-
 class PointDeviationMonitor(SingleDroneMissionMonitor):
 
     def __init__(self, mission, deviation_percentage=15):
@@ -129,7 +128,7 @@ class PointDeviationMonitor(SingleDroneMissionMonitor):
             title = f"{self.target_drone} Planned vs. Actual\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}"
         else:
             title = f"(FAILED) {self.target_drone} Planned vs. Actual\nDrone speed: {self.mission.speed} m/s\nWind: {self.wind_speed_text}"
-        grapher = ThreeDimensionalGrapher()
+        grapher = ThreeDimensionalGrapher(self.storage_service, self.log_subdir)
         grapher.draw_trace_vs_planned(planed_position_list=self.mission.points,
                                       actual_position_list=self.est_position_array,
                                       full_target_directory=graph_dir,

--- a/backend/PythonClient/multirotor/util/graph/three_dimensional_grapher.py
+++ b/backend/PythonClient/multirotor/util/graph/three_dimensional_grapher.py
@@ -4,6 +4,7 @@ import matplotlib
 import plotly.express as px
 import os
 import threading
+from datetime import datetime
 from io import BytesIO
 from PythonClient.multirotor.airsim_application import AirSimApplication
 
@@ -16,7 +17,7 @@ class ThreeDimensionalGrapher(AirSimApplication):
 
     def __init__(self):
         super().__init__()
-
+        self.timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     #Function to upload html files to GCS. 
     def _upload_html(self, fig, file_name):
         html_content = fig.to_html(full_html=True)
@@ -49,9 +50,8 @@ class ThreeDimensionalGrapher(AirSimApplication):
             ax.set_ylabel('East (+Y) axis')
             ax.set_zlabel('Height (+Z) axis')
 
-            file_name = f"{drone_name}_plot.png" 
-            full_target_directory = os.path.join(self.log_subdir, self.__class__.__name__, file_name)
-            self._upload_plot(full_target_directory ,fig)
+            full_target_directory = f"{self.timestamp}_Batch_1/FlyToPoints/{self.__class__.__name__}/{drone_name}_plot.png" 
+            self._upload_plot(fig, full_target_directory)
 
     def draw_trace_vs_planned(self, planed_position_list, full_target_directory, actual_position_list, drone_name,
                             title):
@@ -79,9 +79,8 @@ class ThreeDimensionalGrapher(AirSimApplication):
             ax.set_zlabel('Height (+Z) axis')
             ax.legend()
 
-            file_name = f"{drone_name}_plot.png"
-            full_target_directory = os.path.join(self.log_subdir, self.__class__.__name__, file_name)
-            self._upload_plot(fig, file_name)
+            full_target_directory = f"{self.timestamp}_Batch_1/FlyToPoints/{self.__class__.__name__}/{drone_name}_plot.png" 
+            self._upload_plot(fig, full_target_directory)
             
     def draw_trace_vs_point(self, destination_point, full_target_directory ,actual_position_list, drone_name,
                             title):
@@ -113,9 +112,8 @@ class ThreeDimensionalGrapher(AirSimApplication):
             ax.set_box_aspect([1, 1, 1])
             ax.legend()
             
-            file_name = f"{drone_name}_plot.png"
-            full_target_directory = os.path.join(self.log_subdir, self.__class__.__name__, file_name)
-            self._upload_plot(fig, file_name)
+            full_target_directory = f"{self.timestamp}_Batch_1/FlyToPoints/{self.__class__.__name__}/{drone_name}_plot.png" 
+            self._upload_plot(fig, full_target_directory)
             
     def draw_interactive_trace(self, actual_position, full_target_directory, drone_name,
                                title):
@@ -137,9 +135,9 @@ class ThreeDimensionalGrapher(AirSimApplication):
             ax.set_ylabel('East (+Y) axis')
             ax.set_zlabel('Height (+Z) axis')
 
-            file_name = f"{drone_name}_interactive_trace.html"
-            self._upload_html(fig, file_name)
-            
+            full_target_directory = f"{self.timestamp}_Batch_1/FlyToPoints/{self.__class__.__name__}/{drone_name}_interactive_trace.html"
+            self._upload_html(fig, full_target_directory)
+
     def draw_interactive_trace_vs_point(self, destination, actual_position, full_target_directory, drone_name
                                         ,title):
         with lock:
@@ -163,9 +161,9 @@ class ThreeDimensionalGrapher(AirSimApplication):
             #                              zaxis_range=[-max_val, max_val]))
             
             
-            file_name = f"{drone_name}_interactive_trace_vs_point.html"
-            full_target_directory = os.path.join(self.log_subdir, self.__class__.__name__, file_name)
-            self._upload_html(fig, file_name)
+            full_target_directory = f"{self.timestamp}_Batch_1/FlyToPoints/{self.__class__.__name__}/{drone_name}_interactive_trace_vs_point.html"
+            self._upload_html(fig, full_target_directory)
+ 
             
     def draw_interactive_trace_vs_planned(self, planed_position_list, actual_position_list, full_target_directory,
                                           drone_name,
@@ -193,6 +191,5 @@ class ThreeDimensionalGrapher(AirSimApplication):
             #                              yaxis_range=[-max_val, max_val],
             #                              zaxis_range=[-max_val, max_val]))
 
-            file_name = f"{drone_name}_interactive_trace_vs_planned.html"
-            full_target_directory = os.path.join(self.log_subdir, self.__class__.__name__, file_name)
-            self._upload_html(fig, file_name)
+            full_target_directory = f"{self.timestamp}_Batch_1/FlyToPoints/{self.__class__.__name__}/{drone_name}_interactive_trace_vs_planned.html"
+            self._upload_html(fig, full_target_directory)


### PR DESCRIPTION
Fixes #165

The local file saving for png and html files was removed and replaced with the new GCS file saving. The reports are all uploaded to the gcs through the ThreeDimensionalGrapher.
 
-Much of the local file saving was removed in order to make way for saving files to the GCS.
-Two functions were added to choose between uploading html files and uploading Png files.
-Each function used to create the graphs are no longer static. This change was needed in order to allow self-calls, no issues has been shown as a result.

GCS uploading was added to each Draw function.
 
This was needed because uploading files directly to GCS improves accessibility and streamlines the storage process by eliminating the need for local file storage.

Updated: 
Issue165 now correctly uploads the files to the correct files paths. All instances of the grapher have been updated to pass log_subdir and storage_service, in order to allow for correct file pathing and uploading. No issues have been found.