### PR TITLE
215 Drone Name Display

### DIFF
--- a/frontend/src/components/Configuration/MissionConfiguration.jsx
+++ b/frontend/src/components/Configuration/MissionConfiguration.jsx
@@ -230,6 +230,13 @@ export default function MissionConfiguration (mission) {
                 return obj
             })
         })
+
+        const updatedDrone = mainJson.getDroneBasedOnIndex(index);
+        if (updatedDrone) {
+            updatedDrone.droneName = e;
+            mainJson.updateDroneBasedOnIndex(index, updatedDrone);
+            setMainJson(SimulationConfigurationModel.getReactStateBasedUpdate(mainJson));
+        }
     }
 
     React.useEffect(() => {

--- a/frontend/src/components/cesium/DroneDragAndDrop.jsx
+++ b/frontend/src/components/cesium/DroneDragAndDrop.jsx
@@ -108,7 +108,7 @@ const DroneDragAndDrop = ({ viewerReady, viewerRef, setCameraByPosition }) => {
                 disableDepthTestDistance: Number.POSITIVE_INFINITY,
               }}
               label={{
-                text: drone.name,
+                text: drone.droneName,
                 font: '14pt',
                 showBackground: true,
                 backgroundColor: Color.CORAL,


### PR DESCRIPTION
Fixes #215 

Updated the text displayed in draganddrop to the label used for the name in missionconfiguration.

Displaying the name of each drone on the map allows the user to easily distinguish where each drone is located on the cesium map.

The text under the label section was updated from drone.name to drone.droneName.