### PR TITLE
Decrement now correctly updates Cesium Map

### DIFF
--- a/frontend/src/components/Configuration/MissionConfiguration.jsx
+++ b/frontend/src/components/Configuration/MissionConfiguration.jsx
@@ -216,9 +216,7 @@ export default function MissionConfiguration (mission) {
     const handleDecrement = () => {
         setDroneCount(droneCount -1)
         setDroneArray(prev => {
-            if (prev.length <= 1) return prev;
-                const removedDrone = prev[prev.length - 1];
-                mainJson.deleteDroneById(removedDrone.id);
+                mainJson.popLastDrone();
                 setMainJson(SimulationConfigurationModel.getReactStateBasedUpdate(mainJson));
                 return prev.slice(0, -1);
             }

--- a/frontend/src/components/Configuration/MissionConfiguration.jsx
+++ b/frontend/src/components/Configuration/MissionConfiguration.jsx
@@ -215,9 +215,17 @@ export default function MissionConfiguration (mission) {
 
     const handleDecrement = () => {
         setDroneCount(droneCount -1)
-        popDrone()
-    }
-
+        setDroneArray(prev => {
+            if (prev.length <= 1) return prev;
+                const removedDrone = prev[prev.length - 1];
+                mainJson.deleteDroneById(removedDrone.id);
+                setMainJson(SimulationConfigurationModel.getReactStateBasedUpdate(mainJson));
+                return prev.slice(0, -1);
+            }
+        );
+      };
+      
+    
     const setDroneName = (e, index) => {
         setDroneArray(objs => {
             return objs.map((obj, i) => {

--- a/frontend/src/model/SimulationConfigurationModel.js
+++ b/frontend/src/model/SimulationConfigurationModel.js
@@ -62,6 +62,11 @@ export class SimulationConfigurationModel {
     this._drones.pop();
   }
 
+  deleteDroneById(droneId) {
+    this._drones = this._drones.filter(drone => drone.id !== droneId);
+  }
+  
+
   static getReactStateBasedUpdate(instance) {
     let model = new SimulationConfigurationModel();
     model.environment = instance.environment;

--- a/frontend/src/model/SimulationConfigurationModel.js
+++ b/frontend/src/model/SimulationConfigurationModel.js
@@ -61,12 +61,7 @@ export class SimulationConfigurationModel {
   popLastDrone() {
     this._drones.pop();
   }
-
-  deleteDroneById(droneId) {
-    this._drones = this._drones.filter(drone => drone.id !== droneId);
-  }
   
-
   static getReactStateBasedUpdate(instance) {
     let model = new SimulationConfigurationModel();
     model.environment = instance.environment;


### PR DESCRIPTION
Fixes #214 

The decrement function correctly reduced the drone count by 1 but it failed to remove the drone from the cesium map. 

My issue fixes this by now correctly updating the cesium map whenever the handle decrement function is called.

I added a new helper function to our list of Drone functions in SimulationConfigurationModel.Js.

This change was needed due to common misplacement mistakes that can occur when dragging more drones than intended.