### PR TITLE
Fix: Development of the Footer Component #230

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import ReportDashboard from './components/ReportDashboard';
 import LandingPage from './LandingPage';
 import AboutUs from './components/AboutUs';
 import NavigationBar from './pages/NavigationBar';
+import Footer from './pages/Footer';
 import './styles.css';
 import NotFound from './pages/NotFound';
 
@@ -22,10 +23,10 @@ function App() {
             <Route exact path='/simulation' element={<Wizard />} />
             <Route exact path='/dashboard' element={<FuzzyDashboard />} />
             <Route exact path='/report-dashboard' element={<ReportDashboard />} />
-            <Route exact path='/' element={<LandingPage />} />
+            <Route exact path='/' element={<><LandingPage /><Footer /></>} />
             <Route exact path='/about-us' element={<AboutUs />} />
             <Route exact path='*' element={<NotFound />} />
-
+            
           </Routes>
         </Router>
       </div>

--- a/frontend/src/pages/Footer.jsx
+++ b/frontend/src/pages/Footer.jsx
@@ -1,0 +1,133 @@
+import { Link } from 'react-router-dom';
+
+const commonButtonStyle = {
+  textDecoration: 'none',
+  padding: '8px 16px',
+  borderRadius: '6px',
+  backgroundColor: 'white',
+  color: '#8c8c8c',
+  fontWeight: 300,
+  fontSize: '14px',
+};
+
+const disabledButtonStyle = {
+  ...commonButtonStyle,
+  border: 'none',
+  cursor: 'not-allowed',
+};
+
+const containerStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '16px',
+  fontFamily: 'Arial, sans-serif',
+  backgroundColor: 'white',
+  color: '#8c8c8c',
+  fontWeight: 300,
+  fontSize: '14px',
+};
+
+function Footer() {
+  return (
+    <>
+      <div
+        style={{
+          backgroundColor: '#f0f0f0',
+          fontSize: '42px',
+          fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+          fontWeight: 400,
+          padding: '20px 0 20px 0',
+        }}
+      >
+        <p style={{ color: 'black', marginLeft: '20px', margin: '0 0 0 20px' }}>
+          Ready to start simulating?
+        </p>
+        <p style={{ color: 'blue', marginLeft: '20px', margin: '0 0 0 20px' }}>
+          Create your first test scenario today.
+        </p>
+
+        <div
+          style={{
+            display: 'flex',
+            gap: '12px',
+            marginLeft: '20px',
+            marginTop: '16px',
+          }}
+        >
+          <Link to='/home'>
+            <button
+              id='get-started-button'
+              style={{
+                backgroundColor: '#2563eb',
+                color: 'white',
+                border: 'none',
+                padding: '12px 24px',
+                borderRadius: '6px',
+                fontSize: '16px',
+                fontWeight: '500',
+                cursor: 'pointer',
+                fontFamily:
+                  'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+              }}
+            >
+              Get Started
+            </button>
+          </Link>
+          <Link to='https://oss-slu.github.io/projects/droneworld/about/'>
+            <button
+              id='view-documentation-button'
+              style={{
+                backgroundColor: 'white',
+                color: '#2563eb',
+                border: '1px solid white',
+                padding: '12px 24px',
+                borderRadius: '6px',
+                fontSize: '16px',
+                fontWeight: '500',
+                cursor: 'pointer',
+                fontFamily:
+                  'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+              }}
+            >
+              View Documentation
+            </button>
+          </Link>
+        </div>
+      </div>
+      <div
+        style={{
+          ...containerStyle,
+          gap: '12px',
+          borderTop: '1px solid #e5e7eb',
+        }}
+      >
+        <a
+          href='https://oss-slu.github.io/projects/droneworld/about/'
+          target='_blank'
+          rel='noopener noreferrer'
+          style={commonButtonStyle}
+        >
+          Documentation
+        </a>
+
+        <a
+          href='https://github.com/oss-slu/DroneWorld/'
+          target='_blank'
+          rel='noopener noreferrer'
+          style={commonButtonStyle}
+        >
+          GitHub
+        </a>
+
+        <button disabled aria-disabled='true' style={disabledButtonStyle}>
+          Support
+        </button>
+      </div>
+
+      <div style={containerStyle}>© 2024 DroneWorld. Built by OSS-SLU. All rights reserved.</div>
+    </>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
Changes:
- Added a Footer component with:
- A call-to-action section (“Ready to start simulating?” + “Create your first test scenario today”)
- Two main action buttons:
- Get Started → navigates to /home
- View Documentation → links to external docs
- Secondary footer links: Documentation, GitHub, and a disabled Support button
- Copyright notice

Why
- Assigned first issue

How to test
- Run the app
- Scroll to the bottom of the page to see the new footer.

Verify:

- The Get Started button routes to /home.
- The View Documentation button opens the docs in a new tab.
- The secondary footer links work correctly.
- The Support button is disabled.