### PR TITLE
added css allowing user to see accepted ranges for wind velocities on simulation page

### DIFF
--- a/frontend/src/components/EnvironmentConfiguration.jsx
+++ b/frontend/src/components/EnvironmentConfiguration.jsx
@@ -669,7 +669,8 @@ const handleSnackBarVisibility = (val) => {
                                 variant="standard" type="number" 
                                 onChange={handleWindChange} 
                                 value={envConf.Wind.Force} 
-                                inputProps={{ min: 0 }}/>
+                                inputProps={{ min: 0 }}
+                                helperText={`Allowed range: 0-50 m/s`}/>
                         </Grid>
                     </Tooltip>
                     {/* )} */}


### PR DESCRIPTION
https://github.com/oss-slu/DroneWorld/issues/237