### PR TITLE
Fix POST Calls

### DIFF
--- a/frontend/src/components/HorizontalLinearStepper.jsx
+++ b/frontend/src/components/HorizontalLinearStepper.jsx
@@ -73,7 +73,7 @@ export default function HorizontalLinearStepper(data) {
     // }
     setActiveStep((prevActiveStep) => prevActiveStep + 1);
     setSkipped(newSkipped);
-    invokePostAPI();
+    addTask();
   };
 
   const handleBack = () => {
@@ -157,7 +157,7 @@ export default function HorizontalLinearStepper(data) {
 
   //meat and potatoes, this function actually makes the call
   //the other end is simulation_server.py line 139
-  async function invokePostAPI() {
+  async function addTask() {
     if (activeStep !== steps.length - 1) return;
 
     const dronesToSend = getDronesForPayload(mainJson);


### PR DESCRIPTION
This is the first step in fixing issue: https://github.com/oss-slu/DroneWorld/issues/249

Desc:
Make it so that inside the dockerized environment, when the user hits the end of the configurator, the POST call successfully sends data to the backend instead of crashing like it currently does

The first of the AC has been acheived, being:
-[x] POST calls are functioning and yielding valid simulations

This was accomplished by fixing how the POST calls are made inside HorizontalLinearStepper.jsx

There is still much work to do in this issue, but this is a good step.

I was able to go into the network tab of the browser and see that the data was send to the backend and then back to the frontend, so allegedly its working. That is all the testing I can do until the simulator is up.

Refactoring Decisions:
I just scrapped the (less than ideal, to say in nicely) way that the POST calls were working, and wrote a whole new function that makes its own data to pass instead of trying to strip the old data at the last minute. This makes the code approximately 4000 times more readable that the minefield of ?????s that was there before, as well as not corrupting the data right at the very end for no reason, allowing us to potentially make multiple calls of of one setup. I also added 2 helper functions to improve code cleanliness.