### PR TITLE
Fix CI bug

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10.12'
+        python-version: '3.10'
 
     - name: Upgrade pip, setuptools, wheel
       run: |


### PR DESCRIPTION
For some unholy reason, Github actions started using python 3.1 instead of 3.10. I have corrected the issue