### PR TITLE
Add IMU configuration into task payload and AirSim settings (defensive casing)

### DIFF
--- a/backend/PythonClient/multirotor/control/simulation_task_manager.py
+++ b/backend/PythonClient/multirotor/control/simulation_task_manager.py
@@ -1,4 +1,4 @@
-import copy
+﻿import copy
 import importlib
 import json
 import math
@@ -187,6 +187,11 @@ class SimulationTaskManager:
                     diff_dict["Sensors"]["Barometer"] = single_drone_setting["Sensors"]["Barometer"]
                 if "Magnetometer" in single_drone_setting["Sensors"]:
                     diff_dict["Sensors"]["Magnetometer"] = single_drone_setting["Sensors"]["Magnetometer"]
+                if "IMU" in single_drone_setting["Sensors"]:
+                    diff_dict["Sensors"]["IMU"] = single_drone_setting["Sensors"]["IMU"]
+                    diff_dict["Sensors"]["Imu"] = single_drone_setting["Sensors"]["IMU"]
+                    # Defensive measure to ensure AirSim config accepts one of the casings
+                    # Since we are not yet able to test dockerized simulator.
                 if "GPS" in single_drone_setting["Sensors"]:
                     diff_dict["Sensors"]["GPS"] = single_drone_setting["Sensors"]["GPS"]
 

--- a/frontend/src/components/HorizontalLinearStepper.jsx
+++ b/frontend/src/components/HorizontalLinearStepper.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+﻿import * as React from 'react';
 import { Box, Grid } from '@mui/material';
 import Stepper from '@mui/material/Stepper';
 import Step from '@mui/material/Step';
@@ -119,6 +119,9 @@ export default function HorizontalLinearStepper(data) {
                   : undefined,
                 Magnetometer: Sensors.Magnetometer
                   ? (({ Key, ...m }) => m)(Sensors.Magnetometer)
+                  : undefined,
+                IMU: Sensors.IMU
+                  ? (({ Key, ...i }) => i)(Sensors.IMU)
                   : undefined,
                 GPS: Sensors.GPS
                   ? (({ Key, ...g }) => g)(Sensors.GPS)


### PR DESCRIPTION
### Summary

This PR completes Issue #44  backend integration for IMU parameters. The IMU values were already captured in the UI (Issue #25 ), but they were never sent to the backend or written into AirSim settings. This change adds IMU to the request payload and passes it through to AirSim settings, with a defensive mapping to support both IMU and Imu key casing.

### Context

UI already collected IMU fields (AngularRandomWalk, GyroBiasStabilityTau, GyroBiasStability, VelocityRandomWalk, AccelBiasStabilityTau, AccelBiasStability), but these values were dropped before submission.

Backend only forwarded Barometer/Magnetometer/GPS into settings.json, so IMU configuration never reached AirSim.

### Changes

Frontend payload includes IMU
- Added IMU to sanitizedSensors in getDronesForPayload (strips Key like other sensors).

Backend writes IMU to settings
- Added IMU pass‑through in __populate_drone_and_mission_settings so the sensor config is written to settings.json.

Defensive casing for IMU/Imu
- Same backend file: writes both Sensors.IMU and Sensors.Imu to avoid casing issues with AirSim expectations.

### Process Followed

- Reviewed Issue #44  and confirmed UI work was completed previously (Issue #25  commits).
- Traced the data path from UI → payload → backend → settings.json.
- Verified payload builder in HorizontalLinearStepper.jsx was omitting IMU.
- Verified backend only forwarded Barometer/Magnetometer/GPS.
- Added defensive mapping for IMU vs Imu due to uncertain AirSim casing.
- Performed repo-wide grep to confirm no other backend sensor config locations exist.