### PR TITLE
feat: update frontend to handle standardized error responses

### DIFF
--- a/frontend/src/components/HorizontalLinearStepper.jsx
+++ b/frontend/src/components/HorizontalLinearStepper.jsx
@@ -16,6 +16,7 @@ import CesiumMap from './cesium/CesiumMap';
 import { mapControls } from '../constants/map';
 import ControlsDisplay from './Configuration/ControlsDisplay';
 import { BASE_URL } from '../utils/const';
+import { parseApiError } from '../utils/apiError';
 
 const StyledButton = styled(Button)`
   border-radius: 25px;
@@ -219,21 +220,20 @@ export default function HorizontalLinearStepper(data) {
         body: JSON.stringify(payload),
       });
 
-      const bodyText = await res.text(); 
-      if (!res.ok) throw new Error(`HTTP ${res.status}: ${bodyText}`);
-
-      let data;
-      try {
-        data = JSON.parse(bodyText);
-      } catch {
-        data = { raw: bodyText };
+      if (!res.ok) {
+        const apiError = await parseApiError(res);
+        console.error('Submit failed:', apiError.code, apiError.details);
+        setSubmitError(apiError.message);
+        return false;
       }
+
+      const data = await res.json();
       console.log('Task queued:', data);
       return true;
 
     } catch (err) {
       console.error('Submit failed:', err);
-      setSubmitError(`Submit failed: ${err.message}`);
+      setSubmitError('Unable to reach the server. Please try again.');
       return false;
     }
   }

--- a/frontend/src/components/ReportDashboard.jsx
+++ b/frontend/src/components/ReportDashboard.jsx
@@ -25,6 +25,7 @@ import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
 import HomeIcon from '@mui/icons-material/Home';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { BASE_URL } from '../utils/const';
+import { getErrorMessage } from '../utils/apiError';
 
 const formatTimestamp = (filename) => {
   if (!filename) return { display: '', sortKey: filename || '' };
@@ -185,13 +186,16 @@ export default function ReportDashboard() {
       setError('');
       try {
         const res = await fetch(`${BASE_URL}/list-reports`);
-        if (!res.ok) throw new Error('Failed to fetch reports');
+        if (!res.ok) {
+          const msg = await getErrorMessage(res);
+          throw new Error(msg);
+        }
         const data = await res.json();
         setReports(data.reports ?? []);
         setSnackOpen((data.reports ?? []).length === 0);
       } catch (err) {
         console.error(err);
-        setError('Could not load reports.');
+        setError(err.message || 'Could not load reports.');
         setSnackOpen(true);
       } finally {
         setIsLoading(false);
@@ -221,7 +225,10 @@ export default function ReportDashboard() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
       });
-      if (!res.ok) throw new Error('Failed to load report contents');
+      if (!res.ok) {
+        const msg = await getErrorMessage(res);
+        throw new Error(msg);
+      }
       const data = await res.json();
       navigate('/dashboard', {
         state: {
@@ -231,7 +238,7 @@ export default function ReportDashboard() {
       });
     } catch (err) {
       console.error(err);
-      setError('Unable to open report. Please try again.');
+      setError(err.message || 'Unable to open report. Please try again.');
       setSnackOpen(true);
     } finally {
       setPreviewing('');

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom';
 import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { BASE_URL } from '../utils/const';
+import { getErrorMessage } from '../utils/apiError';
 
 const StyledButton = styled(Button)`
   align-items: center;
@@ -79,8 +80,14 @@ const Home = () => {
   useEffect(() => {
     const fetchStatus = () => {
       Promise.all([
-      fetch(`${BASE_URL}/currentRunning`).then((res) => res.json()),
-      fetch(`${BASE_URL}/state`).then((res) => res.json()),
+      fetch(`${BASE_URL}/currentRunning`).then(async (res) => {
+        if (!res.ok) { const msg = await getErrorMessage(res); throw new Error(msg); }
+        return res.json();
+      }),
+      fetch(`${BASE_URL}/state`).then(async (res) => {
+        if (!res.ok) { const msg = await getErrorMessage(res); throw new Error(msg); }
+        return res.json();
+      }),
     ])
       .then(([queueInfo, simState]) => {
         const queueSize = parseInt(queueInfo.queue_size, 10) || 0;

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -18,6 +18,7 @@ import ShowChartIcon from '@mui/icons-material/ShowChart';
 import GroupWorkIcon from '@mui/icons-material/GroupWork';
 import InsertChartOutlinedIcon from '@mui/icons-material/InsertChartOutlined';
 import { BASE_URL } from '../utils/const';
+import { getErrorMessage } from '../utils/apiError';
 
 const useStyles = makeStyles(() => ({
   landingPage: {
@@ -103,6 +104,11 @@ export default function LandingPage() {
       setIsloading(true);
       try {
         const response = await fetch(`${BASE_URL}/list-reports`, { method: 'GET' });
+        if (!response.ok) {
+          const msg = await getErrorMessage(response);
+          console.error('Error fetching report data:', msg);
+          return;
+        }
         const data = await response.json();
         const batchFiles = data.reports.filter((file) => file.filename.includes('Batch'));
         setFilesPresent(batchFiles.length > 0);

--- a/frontend/src/tests/apiError.test.js
+++ b/frontend/src/tests/apiError.test.js
@@ -1,0 +1,92 @@
+/* eslint-env jest */
+import { parseApiError, getErrorMessage } from '../utils/apiError';
+
+function mockResponse(body, status = 500, headers = {}) {
+  const headersMap = new Headers(headers);
+  return {
+    status,
+    ok: false,
+    headers: headersMap,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function mockTextResponse(status = 500, headers = {}) {
+  const headersMap = new Headers(headers);
+  return {
+    status,
+    ok: false,
+    headers: headersMap,
+    json: () => Promise.reject(new Error('not json')),
+  };
+}
+
+describe('parseApiError', () => {
+  test('extracts fields from standard error envelope', async () => {
+    const res = mockResponse(
+      {
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Invalid drone data',
+          details: { missing_fields: ['id'] },
+          timestamp: '2025-11-18T10:30:00Z',
+          request_id: 'abc-123',
+        },
+      },
+      422,
+    );
+    const parsed = await parseApiError(res);
+    expect(parsed.code).toBe('VALIDATION_ERROR');
+    expect(parsed.message).toBe('Invalid drone data');
+    expect(parsed.details).toEqual({ missing_fields: ['id'] });
+    expect(parsed.requestId).toBe('abc-123');
+  });
+
+  test('falls back when response is not JSON', async () => {
+    const res = mockTextResponse(502);
+    const parsed = await parseApiError(res);
+    expect(parsed.code).toBe('UNKNOWN_ERROR');
+    expect(parsed.message).toContain('502');
+  });
+
+  test('falls back for non-standard JSON body', async () => {
+    const res = mockResponse({ msg: 'something went wrong' }, 500);
+    const parsed = await parseApiError(res);
+    expect(parsed.code).toBe('UNKNOWN_ERROR');
+    expect(parsed.message).toContain('500');
+  });
+
+  test('reads X-Request-ID header when request_id is missing from body', async () => {
+    const res = mockResponse(
+      {
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Unexpected error',
+          details: {},
+        },
+      },
+      500,
+      { 'X-Request-ID': 'header-id-456' },
+    );
+    const parsed = await parseApiError(res);
+    expect(parsed.requestId).toBe('header-id-456');
+  });
+});
+
+describe('getErrorMessage', () => {
+  test('returns just the message string', async () => {
+    const res = mockResponse(
+      {
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: 'Drone not found',
+          details: { drone_id: 'Drone3' },
+          request_id: 'xyz',
+        },
+      },
+      404,
+    );
+    const msg = await getErrorMessage(res);
+    expect(msg).toBe('Drone not found');
+  });
+});

--- a/frontend/src/utils/apiError.js
+++ b/frontend/src/utils/apiError.js
@@ -1,0 +1,66 @@
+/**
+ * Parses the standardized error response envelope returned by the backend.
+ *
+ * Expected shape:
+ * {
+ *   "error": {
+ *     "code": "VALIDATION_ERROR",
+ *     "message": "User-friendly message",
+ *     "details": { ... },
+ *     "timestamp": "2025-11-18T10:30:00Z",
+ *     "request_id": "550e8400-e29b-41d4-a716-446655440000"
+ *   }
+ * }
+ */
+
+/**
+ * Extract a user-friendly message from a failed fetch Response.
+ *
+ * If the response body matches the standard error envelope, the `message`
+ * field is returned.  Otherwise a generic fallback is built from the HTTP
+ * status code and any available text.
+ *
+ * @param {Response} response - The fetch Response object (already known to be !ok).
+ * @returns {Promise<{code: string, message: string, details: object, requestId: string}>}
+ */
+export async function parseApiError(response) {
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    return {
+      code: 'UNKNOWN_ERROR',
+      message: `Request failed with status ${response.status}`,
+      details: {},
+      requestId: response.headers.get('X-Request-ID') || '',
+    };
+  }
+
+  if (body && body.error && body.error.code) {
+    return {
+      code: body.error.code,
+      message: body.error.message || 'An error occurred',
+      details: body.error.details || {},
+      requestId: body.error.request_id || response.headers.get('X-Request-ID') || '',
+    };
+  }
+
+  return {
+    code: 'UNKNOWN_ERROR',
+    message: body.message || body.error || `Request failed with status ${response.status}`,
+    details: {},
+    requestId: response.headers.get('X-Request-ID') || '',
+  };
+}
+
+/**
+ * Convenience wrapper: extracts just the user-facing message string from a
+ * failed response.  Useful when the caller only needs to display a message.
+ *
+ * @param {Response} response
+ * @returns {Promise<string>}
+ */
+export async function getErrorMessage(response) {
+  const parsed = await parseApiError(response);
+  return parsed.message;
+}


### PR DESCRIPTION
## Summary

Completes the frontend side of #268 — the backend error middleware and custom exception classes were already in place (added in `2f8cd91`), but the frontend was still using raw error messages and generic catch-all handlers.

### Changes

- **New `apiError.js` utility** (`frontend/src/utils/apiError.js`) — parses the standard `{ error: { code, message, details, request_id } }` envelope returned by the backend, with fallbacks for non-JSON or non-standard responses.
- **Updated `HorizontalLinearStepper.jsx`** — task submission errors now show the backend's user-friendly `message` instead of raw `HTTP 422: ...` strings.
- **Updated `ReportDashboard.jsx`** — report listing and preview errors surface the backend message.
- **Updated `Home.jsx`** — status polling checks `res.ok` before parsing JSON and extracts the error message on failure.
- **Updated `LandingPage.jsx`** — report fetch checks `res.ok` and logs the parsed error message.
- **New test suite** (`frontend/src/tests/apiError.test.js`) — 5 tests covering standard envelope parsing, non-JSON fallback, non-standard body fallback, `X-Request-ID` header extraction, and the `getErrorMessage` convenience wrapper.

### Acceptance criteria addressed

- [x] Frontend code is updated to handle the new error format consistently
- [x] All components that call the backend now check `res.ok` before parsing
- [x] User-friendly messages from the backend are surfaced to the UI
- [x] Tests cover the error parsing utility

## Test plan

- [x] `npx react-scripts test --watchAll=false --testPathPattern=apiError` — all 5 tests pass
- [ ] Manual: trigger a validation error (e.g. submit a task without drones) and verify the UI shows the backend's message instead of a raw HTTP error
- [ ] Manual: stop the backend and verify network errors show a friendly fallback message